### PR TITLE
fix flags in --help (clear branch)

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -300,6 +300,7 @@ void parseCommandLine(int argc, char** argv) {
 				}
 				if (g_useColors) {
 					putc(' ', stdout);
+					g_isatty = false;
 					for (const auto& color : flag.second.colors) {
 						setBackgroundColor(color);
 						putc(' ', stdout);


### PR DESCRIPTION
turns out the clearing of the whole line breaks the little inline flags, so i thought it would be fine to just overwrite `g_isatty` on help output